### PR TITLE
Pass empty context into modifiers

### DIFF
--- a/src/Extensions/ModifierExtension.php
+++ b/src/Extensions/ModifierExtension.php
@@ -46,6 +46,6 @@ class ModifierExtension extends Extension
 
     protected function applyModifier(string $name, $value, ...$args): mixed
     {
-        return ($this->loader->load($name))($value, $args);
+        return ($this->loader->load($name))($value, $args, []);
     }
 }


### PR DESCRIPTION
Pass empty array into modifier methods to simulate an empty `$context` argument. Okay for now. Need to research how to pass the actual context into there. Not sure if that even applies with Latte...

Closes #6 