### PR TITLE
Normalize arrays before n:attr spread

### DIFF
--- a/src/Latte/Extensions/AttributeNormalizationExtension.php
+++ b/src/Latte/Extensions/AttributeNormalizationExtension.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Daun\StatamicLatte\Latte\Extensions;
+
+use Latte\Compiler\Node;
+use Latte\Compiler\Nodes\Php\Expression\AuxiliaryNode;
+use Latte\Compiler\Nodes\Php\ExpressionNode;
+use Latte\Compiler\Nodes\TemplateNode;
+use Latte\Compiler\NodeTraverser;
+use Latte\Compiler\PrintContext;
+use Latte\Essential\Nodes\NAttrNode;
+use Latte\Extension;
+
+/**
+ * Teaches Latte's native {n:attr} to accept Statamic Content objects.
+ *
+ * Normalizer maps keyed arrays to a Content object so templates reach them with
+ * `->`. Latte's n:attr runtime does an is_array() check, so a Content is
+ * silently dropped — `<div n:attr="$attrs">` would render no attributes. This
+ * pass wraps every n:attr argument in Normalizer::unwrap(), peeling Content
+ * back to a plain array at that boundary. unwrap() is a no-op for scalars and
+ * strings, so the keyed forms (`n:attr="href: …, class: …"`) are unaffected.
+ */
+class AttributeNormalizationExtension extends Extension
+{
+    public function getPasses(): array
+    {
+        return [
+            'statamic-latte-attribute-normalization' => [self::class, 'unwrapPass'],
+        ];
+    }
+
+    public static function unwrapPass(TemplateNode $template): void
+    {
+        (new NodeTraverser)->traverse($template, function (Node $node) {
+            if ($node instanceof NAttrNode) {
+                foreach ($node->args->items as $item) {
+                    $item->value = self::unwrap($item->value);
+                }
+            }
+
+            return $node;
+        });
+    }
+
+    protected static function unwrap(ExpressionNode $value): AuxiliaryNode
+    {
+        return new AuxiliaryNode(
+            fn (PrintContext $context, ExpressionNode $inner): string => '\Daun\StatamicLatte\Data\Normalizer::unwrap('.$inner->print($context).')',
+            [$value],
+        );
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -14,6 +14,7 @@ class ServiceProvider extends AddonServiceProvider
 {
     public static $defaultExtensions = [
         Extensions\AntlersExtension::class,
+        Extensions\AttributeNormalizationExtension::class,
         Extensions\CacheExtension::class,
         Extensions\LayoutExtension::class,
         Extensions\ModifierExtension::class,

--- a/tests/Feature/NAttributeTest.php
+++ b/tests/Feature/NAttributeTest.php
@@ -100,6 +100,17 @@ describe('n:attr', function () {
             ->assertSee('href="/snacks"', false)
             ->assertSee('class="btn"', false);
     });
+    test('spreads an associative array passed as a Content object', function () {
+        $this->latte('<div n:attr="$attrs">x</div>', [
+            'attrs' => ['class' => 'big', 'data-id' => 7, 'hidden' => true, 'title' => null],
+        ])
+            ->assertSee('<div class="big" data-id="7" hidden>x</div>', false);
+    });
+
+    test('still renders a keyed n:attr after the unwrap pass', function () {
+        $this->latte('<a n:attr="href: $url, class: \'btn\'">x</a>', ['url' => '/go'])
+            ->assertSee('<a href="/go" class="btn">x</a>', false);
+    });
 });
 
 describe('interpolation', function () {


### PR DESCRIPTION
`<div n:attr="$attrs">` currently fails with wrapped/augmentable/lazyloaded keyed collections.