### PR TITLE
Slot alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,52 @@ Sections and yields share Statamic's underlying content store, so they interoper
 freely across Latte, Antlers and Blade templates: a section defined in an Antlers
 partial can be yielded in a Latte layout, and vice versa.
 
+### Embeds & Slots
+
+Latte composes templates with [`{embed}`](https://latte.nette.org/en/template-inheritance#toc-horizontal-reuse)
+and [`{block}`](https://latte.nette.org/en/template-inheritance): a partial defines
+named, fillable regions with `{block}`, and the embedding template overrides them
+inside `{embed}`.
+
+For parity with the component/slot vocabulary used by Antlers and Blade, `{slot}` is
+provided as an **exact alias for `{block}`**. It is a pure synonym — same parsing, same
+rendering — so you can use slot terminology on both sides of an embed:
+
+```latte
+{* partials/figure.latte *}
+
+<figure>
+    <img src="{$src}" alt="{$alt}">
+    <figcaption>{slot caption}Default caption{/slot}</figcaption>
+</figure>
+```
+
+```latte
+{* template *}
+
+{embed file 'partials.figure', src: $image->url, alt: $image->alt}
+    {slot caption}A custom caption{/slot}
+{/embed}
+```
+
+Because `{slot}` is identical to `{block}`, the two are interchangeable everywhere
+(including layouts and `{extends}`) and you can freely mix them. Omitting a slot in the
+embed falls back to the default content defined in the partial.
+
+The `n:slot` attribute is also available (mirroring `n:block`) and works on both sides:
+
+```latte
+{* partials/figure.latte *}
+
+<figcaption n:ifcontent n:slot="caption">Default caption</figcaption>
+
+{* template *}
+
+{embed file 'partials.figure'}
+    <figcaption n:slot="caption">A custom caption</figcaption>
+{/embed}
+```
+
 ### Caching
 
 #### Cache

--- a/src/Latte/Extensions/SlotExtension.php
+++ b/src/Latte/Extensions/SlotExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Daun\StatamicLatte\Latte\Extensions;
+
+use Latte\Essential\Nodes\BlockNode;
+use Latte\Extension;
+
+/**
+ * Latte extension that adds {slot} as an alias for the core {block} tag.
+ *
+ * {slot} is a pure synonym for {block} and works in every context a block
+ * does: defining a named, fillable region in a partial and filling it from
+ * inside an {embed}. Parsing and rendering defer entirely to {block}, and
+ * because the resulting node is a BlockNode it satisfies the content check
+ * that {embed} performs on its body.
+ */
+class SlotExtension extends Extension
+{
+    public function getTags(): array
+    {
+        return [
+            'slot' => [BlockNode::class, 'create'],
+        ];
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -20,6 +20,7 @@ class ServiceProvider extends AddonServiceProvider
         Extensions\ModifierExtension::class,
         Extensions\ResolverExtension::class,
         Extensions\SectionExtension::class,
+        Extensions\SlotExtension::class,
         Extensions\TagExtension::class,
     ];
 

--- a/tests/Feature/SlotTest.php
+++ b/tests/Feature/SlotTest.php
@@ -50,4 +50,84 @@ describe('slot', function () {
 
         expect($output)->toContain('Hi');
     });
+
+    test('supports the n:slot attribute when filling from an embed', function () {
+        $output = renderLatte([
+            'figure' => '<figure><figcaption>{slot caption}{/slot}</figcaption></figure>',
+            'main' => "{embed file 'figure'}<span n:slot=\"caption\">Hello</span>{/embed}",
+        ]);
+
+        expect(trim($output))->toBe('<figure><figcaption><span>Hello</span></figcaption></figure>');
+    });
+
+    test('supports the n:slot attribute when defining a default in a partial', function () {
+        $output = renderLatte([
+            'figure' => '<figcaption n:ifcontent n:slot="caption">Default caption</figcaption>',
+            'main' => "{embed file 'figure'}{/embed}",
+        ]);
+
+        expect(trim($output))->toBe('<figcaption>Default caption</figcaption>');
+    });
+
+    test('a filled n:slot overrides the default element content', function () {
+        $output = renderLatte([
+            'figure' => '<figure><figcaption n:slot="caption">Default</figcaption></figure>',
+            'main' => "{embed file 'figure'}<figcaption n:slot=\"caption\">Filled</figcaption>{/embed}",
+        ]);
+
+        expect(trim($output))->toBe('<figure><figcaption>Filled</figcaption></figure>');
+    });
+
+    test('supports the n:inner-slot attribute when defining a default in a partial', function () {
+        $output = renderLatte([
+            'figure' => '<figure><figcaption n:inner-slot="caption">Default</figcaption></figure>',
+            'main' => "{embed file 'figure'}{/embed}",
+        ]);
+
+        expect(trim($output))->toBe('<figure><figcaption>Default</figcaption></figure>');
+    });
+
+    test('an n:inner-slot default is overridden when the slot is filled', function () {
+        $output = renderLatte([
+            'figure' => '<figure><figcaption n:inner-slot="caption">Default</figcaption></figure>',
+            'main' => "{embed file 'figure'}{slot caption}Filled{/slot}{/embed}",
+        ]);
+
+        expect(trim($output))->toBe('<figure><figcaption>Filled</figcaption></figure>');
+    });
+
+    test('an n:inner-slot default is overridden by an n:slot fill', function () {
+        $output = renderLatte([
+            'figure' => '<figure><figcaption n:inner-slot="caption">Default</figcaption></figure>',
+            'main' => "{embed file 'figure'}<span n:slot=\"caption\">Filled</span>{/embed}",
+        ]);
+
+        expect(trim($output))->toBe('<figure><figcaption><span>Filled</span></figcaption></figure>');
+    });
+
+    test('n:inner-slot behaves identically to n:inner-block', function () {
+        $withBlock = renderLatte([
+            'figure' => '<figure><figcaption n:inner-block="caption">Default</figcaption></figure>',
+            'main' => "{embed file 'figure'}{/embed}",
+        ]);
+        $withSlot = renderLatte([
+            'figure' => '<figure><figcaption n:inner-slot="caption">Default</figcaption></figure>',
+            'main' => "{embed file 'figure'}{/embed}",
+        ]);
+
+        expect($withSlot)->toBe($withBlock);
+    });
+
+    test('n:slot behaves identically to n:block', function () {
+        $withBlock = renderLatte([
+            'figure' => '<figcaption n:block="caption">Default</figcaption>',
+            'main' => "{embed file 'figure'}<figcaption n:block=\"caption\">Filled</figcaption>{/embed}",
+        ]);
+        $withSlot = renderLatte([
+            'figure' => '<figcaption n:slot="caption">Default</figcaption>',
+            'main' => "{embed file 'figure'}<figcaption n:slot=\"caption\">Filled</figcaption>{/embed}",
+        ]);
+
+        expect($withSlot)->toBe($withBlock);
+    });
 });

--- a/tests/Feature/SlotTest.php
+++ b/tests/Feature/SlotTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Latte\Engine;
+use Latte\Loaders\StringLoader;
+
+function renderLatte(array $templates, string $entry = 'main'): string
+{
+    $engine = app(Engine::class);
+    $engine->setLoader(new StringLoader($templates));
+
+    return $engine->renderToString($entry);
+}
+
+describe('slot', function () {
+    test('fills a named slot of an embedded template', function () {
+        $output = renderLatte([
+            'figure' => '<figure><figcaption>{slot caption}{/slot}</figcaption></figure>',
+            'main' => "{embed file 'figure'}{slot caption}Hello{/slot}{/embed}",
+        ]);
+
+        expect($output)->toContain('<figcaption>Hello</figcaption>');
+    });
+
+    test('defines a default that is used when the slot is not filled', function () {
+        $output = renderLatte([
+            'figure' => '<figure><figcaption>{slot caption}Default{/slot}</figcaption></figure>',
+            'main' => "{embed file 'figure'}{/embed}",
+        ]);
+
+        expect($output)->toContain('<figcaption>Default</figcaption>');
+    });
+
+    test('behaves identically to {block} on both sides', function () {
+        $withBlock = renderLatte([
+            'figure' => '<figure><figcaption>{block caption}{/block}</figcaption></figure>',
+            'main' => "{embed file 'figure'}{block caption}Hello{/block}{/embed}",
+        ]);
+        $withSlot = renderLatte([
+            'figure' => '<figure><figcaption>{slot caption}{/slot}</figcaption></figure>',
+            'main' => "{embed file 'figure'}{slot caption}Hello{/slot}{/embed}",
+        ]);
+
+        expect($withSlot)->toBe($withBlock);
+    });
+
+    test('works outside an embed as a plain block alias', function () {
+        $output = renderLatte([
+            'main' => '{slot greeting}Hi{/slot}',
+        ]);
+
+        expect($output)->toContain('Hi');
+    });
+});


### PR DESCRIPTION
Establish `slot` as exact alias for `block`. Useful for parity with Antlers/Blade terminology.

 ### `{slot}` paired tag

 Define a fillable region in a partial, fill it from the embed:

 ```latte
   {* partials/figure.latte *}
   <figure>
     <figcaption>{slot caption}Default caption{/slot}</figcaption>
   </figure>
 ```

 ```latte
   {embed file 'partials.figure'}
     {slot caption}A custom caption{/slot}
   {/embed}
 ```

 ```html
   <figure>
     <figcaption>A custom caption</figcaption>
   </figure>
 ```

 Omit the slot to keep the default:

 ```latte
   {embed file 'partials.figure'}{/embed}
 ```

 ```html
   <figure>
     <figcaption>Default caption</figcaption>
   </figure>
 ```

 ### `n:slot` attribute
 ```latte
   {* partials/figure.latte *}
   <figure><figcaption>{slot caption}{/slot}</figcaption></figure>
 ```

 ```latte
   {embed file 'partials.figure'}
     <span n:slot="caption">Hello</span>
   {/embed}
 ```

 ```html
   <figure><figcaption><span>Hello</span></figcaption></figure>
 ```

 Defining with n:slot on both sides (fill replaces the element's content):

 ```latte
   {* partial *} <figure><figcaption n:slot="caption">Default</figcaption></figure>
   {* template *} {embed file 'partials.figure'}<figcaption n:slot="caption">Filled</figcaption>{/embed}
 ```

 ```html
   <figure><figcaption>Filled</figcaption></figure>
 ```

 ### `n:inner-slot` attribute

 Best for defining a default in a partial:

 ```latte
   {* partials/figure.latte *}
   <figure><figcaption n:inner-slot="caption">Default</figcaption></figure>
 ```

 Overridden by a fill from the embed:

 ```latte
   {embed file 'partials.figure'}
     {slot caption}Filled{/slot}
   {/embed}
 ```

 ```html
   <figure><figcaption>Filled</figcaption></figure>
 ```

⚠️ `n:inner-slot` works for defining defaults but cannot fill inside `{embed}` (compile error `Unexpected content inside {embed} tags`). `{embed}` bodies only accept block/import/text as direct children. Use `{slot}` or `n:slot` to fill.